### PR TITLE
restart wpa_supplicant after stop 

### DIFF
--- a/PyAccessPoint/pyaccesspoint.py
+++ b/PyAccessPoint/pyaccesspoint.py
@@ -238,6 +238,12 @@ class AccessPoint:
         logging.debug(r.strip())
         # self.execute_shell('ifconfig ' + wlan + ' down'  + IP + ' netmask ' + Netmask)
         # self.execute_shell('ip addr flush ' + wlan)
+
+        # restart wpa_supplicant
+        logging.debug('restarting wpa_supplicant')
+        r = self._execute_shell('wpa_supplicant -B -c/etc/wpa_supplicant/wpa_supplicant.conf -i wlan0')
+        logging.debug(r.strip())
+
         logging.debug('hotspot has stopped.')
         return True
 


### PR DESCRIPTION
Added restarting of wpa_supplicant to enable wifi back after AP stop. #4
Tested it on Raspberry Pi OS 11 and 10.